### PR TITLE
Expose script metrics on the /metrics path instead.

### DIFF
--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -378,15 +378,13 @@ func main() {
 	// required for all routes.
 	router := http.NewServeMux()
 
-	router.Handle("/probe", setupMetrics(metricsHandler))
-	router.Handle("/metrics", promhttp.Handler())
+	router.Handle("/metrics", setupMetrics(metricsHandler))
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
 		<head><title>Script Exporter</title></head>
 		<body>
 		<h1>Script Exporter</h1>
 		<p><a href='/metrics'>Metrics</a></p>
-		<p><a href='/probe'>Probe</a></p>
 		<p><ul>
 		<li>version: ` + version.Version + `</li>
 		<li>branch: ` + version.Branch + `</li>

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -169,7 +169,6 @@ func instrumentScript(obs prometheus.ObserverVec, cnt *prometheus.CounterVec, g 
 func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	// Get script from url parameter
 	params := r.URL.Query()
-	scriptName := params.Get("script")
 
 	// Get prefix from url parameter
 	prefix := params.Get("prefix")
@@ -192,8 +191,10 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	scriptStartTime := time.Now()
 
 	// Get and run script
-	script := exporterConfig.Scripts[0].Script
-	fmt.Printf("Running script: %v", script)
+	scriptConfig := exporterConfig.Scripts[0]
+	script := scriptConfig.Script
+	scriptName := scriptConfig.Name
+	fmt.Printf("Running script: %v", scriptName)
 	if script == "" {
 		log.Printf("Script not found\n")
 		http.Error(w, "Script not found", http.StatusBadRequest)

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -194,7 +194,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	scriptConfig := exporterConfig.Scripts[0]
 	script := scriptConfig.Script
 	scriptName := scriptConfig.Name
-	fmt.Printf("Running script: %v", scriptName)
+	fmt.Printf("Running script: %v - with timeout: %v", scriptConfig.Name, scriptConfig.Timeout)
 	if script == "" {
 		log.Printf("Script not found\n")
 		http.Error(w, "Script not found", http.StatusBadRequest)

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -145,7 +145,7 @@ func getTimeout(r *http.Request, offset float64, maxTimeout float64) float64 {
 // parameter are not instrumented (and will probably be rejected).
 func instrumentScript(obs prometheus.ObserverVec, cnt *prometheus.CounterVec, g *prometheus.GaugeVec, next http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		sn := r.URL.Query().Get("script")
+		sn := exporterConfig.Scripts[0].Name
 		if sn == "" {
 			// Rather than make up a fake script label, such
 			// as "NONE", we let the request fall through without
@@ -170,11 +170,6 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	// Get script from url parameter
 	params := r.URL.Query()
 	scriptName := params.Get("script")
-	if scriptName == "" {
-		log.Printf("Script parameter is missing\n")
-		http.Error(w, "Script parameter is missing", http.StatusBadRequest)
-		return
-	}
 
 	// Get prefix from url parameter
 	prefix := params.Get("prefix")
@@ -197,7 +192,8 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	scriptStartTime := time.Now()
 
 	// Get and run script
-	script := exporterConfig.GetScript(scriptName)
+	script := exporterConfig.Scripts[0].Script
+	fmt.Printf("Running script: %v", script)
 	if script == "" {
 		log.Printf("Script not found\n")
 		http.Error(w, "Script not found", http.StatusBadRequest)


### PR DESCRIPTION
Simplified script_exporter by exposing script metrics under /metrics.

This is done by getting the script name param from the config instead of parsing it from queryParams when hitting /probe?script=script-name.

This makes it easier for prometheus to scrape and makes a lot of extra prometheus configuration redundant. 
It does however limit the number of scripts we run to just 1. Though that should be ok for now.

